### PR TITLE
iface: headless data-stream scoping — --monitor-only / --iface (#35)

### DIFF
--- a/docs/views/interfaces.md
+++ b/docs/views/interfaces.md
@@ -103,6 +103,39 @@ monitor capture is a separate pcap handle bound to a specific
 monitor interface — WiFi SIGINT views are already governed by the
 `m` (monitor-iface) selection.
 
+## Headless data-stream scoping (`--monitor-only` / `--iface`)
+
+The `y` toggle is interactive — it needs an operator at the terminal.
+An appliance that runs sloth headless (in a pty, under systemd, with no
+one to press keys) can't use it, so the same data-stream filter is also
+settable at launch:
+
+- `--monitor-only` — at startup, resolve the monitor-mode Wi-Fi
+  interface and restrict the `any` capture to it. Every other iface
+  (loopback, docker, wired, VPN, non-monitor Wi-Fi) is dropped in the
+  pcap callback before decode, exactly as a `y`-deselect would. The
+  802.11 SIGINT rides its own monitor handle and is untouched — the net
+  effect is "watch only the wireless monitor radio." If no monitor
+  interface is found (e.g. it lost the boot race), the restriction is
+  **skipped with a warning** rather than blinding the sensor; the unit's
+  `Restart=always` then re-resolves it once the radio settles.
+- `--iface NAME` — the explicit form: name the interface(s) to keep
+  (repeatable). Anything not named is dropped. `--monitor-only` is
+  sugar for "`--iface <the monitor radio>`".
+
+Both feed a launch-time **allow-list** (`iface_only`). A non-empty
+allow-list is a whitelist; an empty one (the default) imposes no
+restriction. The allow-list composes with the interactive deselect via
+OR in the callback — either election excluding an iface drops its
+frames. Allow-list-excluded rows show the same `d` marker in the view.
+
+Example (the FennecTrace sensor unit):
+
+```
+ExecStart=… /opt/sloth/sloth --monitor-only --hop \
+    --data-socket tcp:127.0.0.1:8765 --pcap-dir /var/lib/fennectrace/pcaps
+```
+
 ## See also
 
 - Backend: [`src/platform/linux_parse.c`](../../src/platform/linux_parse.c).

--- a/include/sloth.h
+++ b/include/sloth.h
@@ -1209,6 +1209,15 @@ typedef struct {
      * and rule_no_monitor_mode() for how it composes with capture. */
     char          iface_deselected[MAX_IFACES][16];
     int           iface_deselected_count;
+    /* Data-stream allow-list — the non-interactive complement to the
+     * deselect election above. When non-empty, ONLY these interfaces feed
+     * the `any` capture; every other iface's packets drop before decode.
+     * Empty (the default) means "no restriction". Seeded once at launch by
+     * --iface / --monitor-only so a headless appliance that can't press the
+     * `y` toggle can still scope the sensor to its wireless monitor radio.
+     * See iface_is_only_allowed() and issue #17's headless follow-up. */
+    char          iface_only[MAX_IFACES][16];
+    int           iface_only_count;
 
     conn_t        conns[MAX_CONNS];
     int           conn_count;
@@ -1494,6 +1503,16 @@ void iface_hide_non_monitor(sloth_state_t *s);
  * any decode / log / alert runs. Purely logical — the OS state of the
  * interface (up/down, monitor, addresses) is never touched. Issue #17. */
 int iface_is_deselected(const sloth_state_t *s, const char *name);
+
+/* ── Iface data-stream allow-list (launch-time monitor-only scoping) ──
+ * Returns 1 if `name` is permitted to feed the data stream: true when the
+ * allow-list is empty (no restriction) or when `name` is on it. The pcap
+ * callback drops any frame whose ingress iface is not allowed, before
+ * decode. iface_only_add() appends a name (deduped, bounded by MAX_IFACES)
+ * and is called from argument parsing (--iface) and monitor-only seeding.
+ * This is the headless complement to the interactive `y` deselect. */
+int  iface_is_only_allowed(const sloth_state_t *s, const char *name);
+void iface_only_add(sloth_state_t *s, const char *name);
 
 /* ── Key routing: does the active view claim this key over the global
  * view-switch letters? Kept in main.c as a small, centralized table;

--- a/src/capture/capture.c
+++ b/src/capture/capture.c
@@ -573,8 +573,13 @@ static void on_packet(u_char *user, const struct pcap_pkthdr *hdr,
         uint32_t ifi = ((uint32_t)data[4] << 24) | ((uint32_t)data[5] << 16)
                      | ((uint32_t)data[6] <<  8) |  (uint32_t)data[7];
         const char *name = ifindex_lookup(ifi);
+        /* Two elections gate the frame, both name-based and both dropping
+         * before any decode: the interactive deselect list (#17) and the
+         * launch-time allow-list (--iface / --monitor-only). A non-empty
+         * allow-list is a whitelist — anything not on it is dropped. */
         if (name && name[0] && g_state
-            && iface_is_deselected(g_state, name))
+            && (iface_is_deselected(g_state, name)
+                || !iface_is_only_allowed(g_state, name)))
             return;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -370,7 +370,7 @@ static void print_usage(const char *argv0) {
     fprintf(stderr,
             "usage: %s [-o FILE] [--pcap-dir DIR] [--eapol-dir DIR] "
             "[--data-socket SPEC] [--no-discovery] [--out-format FORMAT]\n"
-            "       [--refresh-ms N] [--hop]\n"
+            "       [--refresh-ms N] [--hop] [--monitor-only] [--iface NAME]\n"
             "       [--snapshot-out FILE] [--baseline-in FILE] [--site-label TEXT]\n"
             "  -o, --out FILE     append JSONL forensic log of all observed\n"
             "                     events to FILE (created if it doesn't exist)\n"
@@ -412,6 +412,21 @@ static void print_usage(const char *argv0) {
             "                     only kernel-state write sloth performs; off by\n"
             "                     default. Needs monitor mode + CAP_NET_ADMIN\n"
             "                     (Linux). No frame is transmitted.\n"
+            "  --monitor-only     scope the data stream to the wireless monitor\n"
+            "                     radio only. At launch, sloth restricts the\n"
+            "                     `any` IP/TCP capture to the monitor-mode Wi-Fi\n"
+            "                     interface, dropping wired/loopback/docker/VPN\n"
+            "                     noise before decode. The 802.11 SIGINT rides a\n"
+            "                     separate handle and is unaffected. Intended for\n"
+            "                     headless/appliance runs where no operator can\n"
+            "                     work the interactive `y` toggle. If no monitor\n"
+            "                     radio is found, the restriction is skipped with\n"
+            "                     a warning (the stream is not blinded).\n"
+            "  --iface NAME       data-stream allow-list (repeatable): only the\n"
+            "                     named interface(s) feed the `any` capture;\n"
+            "                     everything else is dropped before decode. The\n"
+            "                     explicit form of --monitor-only for when you\n"
+            "                     want to name the interface(s) yourself.\n"
             "  --no-discovery     suppress the mDNS advertisement of the data\n"
             "                     socket. By default, when --data-socket is bound\n"
             "                     to a routable (non-loopback) TCP address, sloth\n"
@@ -460,6 +475,9 @@ int main(int argc, char **argv) {
     const char *site_label     = NULL; /* --site-label   TEXT  (#27) */
     int         refresh_ms   = 0;        /* 0 = use POLL_MS default */
     int         no_discovery = 0;        /* --no-discovery: suppress mDNS advert (#29) */
+    int         monitor_only = 0;        /* --monitor-only: scope data stream to the wireless monitor radio */
+    const char *only_ifaces[MAX_IFACES]; /* --iface NAME (repeatable): launch-time data-stream allow-list */
+    int         only_iface_count = 0;
     time_t      session_start = time(NULL);
     for (int i = 1; i < argc; i++) {
         if ((!strcmp(argv[i], "-o") || !strcmp(argv[i], "--out")) && i + 1 < argc) {
@@ -499,6 +517,15 @@ int main(int argc, char **argv) {
             g_hop_enabled = 1;
         } else if (!strcmp(argv[i], "--no-discovery")) {
             no_discovery = 1;
+        } else if (!strcmp(argv[i], "--monitor-only")) {
+            monitor_only = 1;
+        } else if (!strcmp(argv[i], "--iface") && i + 1 < argc) {
+            /* Collected now, applied to g_state after the memset below —
+             * the allow-list lives in state, which isn't zeroed yet. */
+            if (only_iface_count < MAX_IFACES)
+                only_ifaces[only_iface_count++] = argv[++i];
+            else
+                i++;   /* silently bounded at MAX_IFACES; skip the value */
         } else if (!strcmp(argv[i], "--snapshot-out") && i + 1 < argc) {
             snapshot_out = argv[++i];
         } else if (!strcmp(argv[i], "--baseline-in") && i + 1 < argc) {
@@ -558,15 +585,42 @@ int main(int argc, char **argv) {
     g_state.poll_ms     = refresh_ms > 0 ? refresh_ms : POLL_MS;
     g_state.active_view = VIEW_DASH;
 
+    /* Launch-time data-stream allow-list. Explicit --iface names are seeded
+     * before capture_start so the very first callback already filters. */
+    for (int i = 0; i < only_iface_count; i++)
+        iface_only_add(&g_state, only_ifaces[i]);
+
     g_platform.init();
     dns_init();
 #ifdef WITH_PCAP
     capture_start(&g_state);
     probe_start(&g_state);
+    /* --monitor-only: scope the data stream to the wireless monitor radio.
+     * probe_start() has just resolved it into probe_iface, so add that to
+     * the allow-list. The 802.11 SIGINT rides a separate monitor handle and
+     * is unaffected; this only silences the `any` IP/TCP path (lo, docker,
+     * wired, VPN) that a headless sensor otherwise forwards as noise.
+     * If no monitor radio was found (e.g. it lost the boot race — the unit
+     * restarts until it settles), warn loudly and leave the stream
+     * unrestricted rather than blinding the sensor. */
+    if (monitor_only) {
+        if (g_state.probe_iface[0]) {
+            iface_only_add(&g_state, g_state.probe_iface);
+            fprintf(stderr,
+                    "sloth: --monitor-only: data stream scoped to %s\n",
+                    g_state.probe_iface);
+        } else {
+            fprintf(stderr,
+                    "sloth: --monitor-only: no monitor-mode interface found; "
+                    "data-stream restriction NOT applied\n");
+        }
+    }
     /* First-launch UX (#25): when a monitor interface is present, open on
      * the RF-aware dashboard rather than the interface list. */
     if (g_state.probe_iface[0])
         g_state.active_view = VIEW_DASH;
+#else
+    (void)monitor_only;   /* no capture pipeline to scope without pcap */
 #endif
     event_wake_init();
     updater_init(check_manifest);

--- a/src/views/iface.c
+++ b/src/views/iface.c
@@ -289,6 +289,31 @@ int iface_is_deselected(const sloth_state_t *s, const char *name) {
     return 0;
 }
 
+/* Declared in sloth.h — the launch-time allow-list. An empty list imposes
+ * no restriction (all ifaces pass, subject to the deselect election). A
+ * non-empty list is a whitelist: only the named ifaces feed the data
+ * stream. Used headless by --iface / --monitor-only where no operator can
+ * work the `y` toggle. See issue #17's headless follow-up. */
+int iface_is_only_allowed(const sloth_state_t *s, const char *name) {
+    if (s->iface_only_count == 0) return 1;   /* no allow-list → all pass */
+    for (int i = 0; i < s->iface_only_count; i++) {
+        if (strncmp(s->iface_only[i], name, 16) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+void iface_only_add(sloth_state_t *s, const char *name) {
+    if (!name || !name[0]) return;
+    for (int i = 0; i < s->iface_only_count; i++) {     /* dedupe */
+        if (strncmp(s->iface_only[i], name, 16) == 0) return;
+    }
+    if (s->iface_only_count < MAX_IFACES) {
+        snprintf(s->iface_only[s->iface_only_count++],
+                 sizeof(s->iface_only[0]), "%s", name);
+    }
+}
+
 /* ── draw ────────────────────────────────────────────────── */
 
 /* Format the monitor radio's scan state into `buf`: the channel list with
@@ -332,7 +357,11 @@ void view_iface_draw(const sloth_state_t *s) {
     for (int i = vp; i < s->iface_count && (i - vp) < rows; i++) {
         const iface_stat_t *f = &s->ifaces[i];
         int hidden     = iface_is_hidden(s, f->name);
-        int deselected = iface_is_deselected(s, f->name);
+        /* 'd' marks any iface excluded from the data stream — whether by
+         * the interactive deselect or a launch-time allow-list (--iface /
+         * --monitor-only). Both mean "contributes nothing to capture". */
+        int deselected = iface_is_deselected(s, f->name)
+                       || !iface_is_only_allowed(s, f->name);
         int is_scan = (s->probe_iface[0] && strncmp(s->probe_iface, f->name, 16) == 0);
         char scanbuf[128];
         if (is_scan) fmt_scan_bar(s, scanbuf, sizeof(scanbuf));
@@ -419,7 +448,11 @@ void view_iface_draw(const sloth_state_t *s) {
     for (int i = 0; i < s->iface_count; i++) {
         const iface_stat_t *f = &s->ifaces[i];
         int hidden     = iface_is_hidden(s, f->name);
-        int deselected = iface_is_deselected(s, f->name);
+        /* 'd' marks any iface excluded from the data stream — whether by
+         * the interactive deselect or a launch-time allow-list (--iface /
+         * --monitor-only). Both mean "contributes nothing to capture". */
+        int deselected = iface_is_deselected(s, f->name)
+                       || !iface_is_only_allowed(s, f->name);
         int is_scan = (s->probe_iface[0] && strncmp(s->probe_iface, f->name, 16) == 0);
         char scanbuf[128];
         if (is_scan) fmt_scan_bar(s, scanbuf, sizeof(scanbuf));

--- a/tests/test_state.c
+++ b/tests/test_state.c
@@ -323,6 +323,87 @@ void test_deselect_independent_of_hide(void) {
     ASSERT_EQ(iface_is_deselected(&s, "eth0"), 1);
 }
 
+/* ── data-stream allow-list (--iface / --monitor-only) — #17 headless ── */
+
+void test_only_empty_allows_all(void) {
+    /* Empty allow-list = no restriction: every iface passes. */
+    sloth_state_t s = make_state_with_ifaces(4);
+    ASSERT_EQ(s.iface_only_count, 0);
+    ASSERT_EQ(iface_is_only_allowed(&s, "eth0"),  1);
+    ASSERT_EQ(iface_is_only_allowed(&s, "wlan0"), 1);
+    ASSERT_EQ(iface_is_only_allowed(&s, "tun0"),  1);
+}
+
+void test_only_whitelists_named_iface(void) {
+    /* A non-empty allow-list is a whitelist: only the named iface passes,
+     * every other iface is excluded. This is the monitor-only behaviour —
+     * seed with the monitor radio, drop the wired/virtual noise. */
+    sloth_state_t s = make_state_with_ifaces(4);
+    iface_only_add(&s, "wlan0");
+    ASSERT_EQ(s.iface_only_count, 1);
+    ASSERT_STR(s.iface_only[0], "wlan0");
+    ASSERT_EQ(iface_is_only_allowed(&s, "wlan0"), 1);
+    ASSERT_EQ(iface_is_only_allowed(&s, "eth0"),  0);
+    ASSERT_EQ(iface_is_only_allowed(&s, "lo"),    0);
+    ASSERT_EQ(iface_is_only_allowed(&s, "tun0"),  0);
+}
+
+void test_only_add_is_deduped(void) {
+    /* Repeated --iface of the same name (or monitor-only over an explicit
+     * --iface) must not grow the list. */
+    sloth_state_t s = make_state_with_ifaces(2);
+    iface_only_add(&s, "wlan0");
+    iface_only_add(&s, "wlan0");
+    ASSERT_EQ(s.iface_only_count, 1);
+}
+
+void test_only_add_multiple(void) {
+    sloth_state_t s = make_state_with_ifaces(4);
+    iface_only_add(&s, "wlan0");
+    iface_only_add(&s, "wlan1");
+    ASSERT_EQ(s.iface_only_count, 2);
+    ASSERT_EQ(iface_is_only_allowed(&s, "wlan0"), 1);
+    ASSERT_EQ(iface_is_only_allowed(&s, "wlan1"), 1);
+    ASSERT_EQ(iface_is_only_allowed(&s, "eth0"),  0);
+}
+
+void test_only_add_ignores_empty(void) {
+    /* --monitor-only with no monitor iface seeds nothing → empty list →
+     * unrestricted (fail-open), never an accidental all-drop. */
+    sloth_state_t s = make_state_with_ifaces(2);
+    iface_only_add(&s, "");
+    iface_only_add(&s, NULL);
+    ASSERT_EQ(s.iface_only_count, 0);
+    ASSERT_EQ(iface_is_only_allowed(&s, "eth0"), 1);
+}
+
+void test_only_is_bounded(void) {
+    /* Allow-list is capped at MAX_IFACES; overflow adds are ignored, not
+     * written out of bounds. */
+    sloth_state_t s = make_state_with_ifaces(2);
+    char nm[16];
+    for (int i = 0; i < MAX_IFACES + 8; i++) {
+        snprintf(nm, sizeof(nm), "if%d", i);
+        iface_only_add(&s, nm);
+    }
+    ASSERT_EQ(s.iface_only_count, MAX_IFACES);
+}
+
+void test_only_independent_of_deselect(void) {
+    /* Allow-list and the interactive deselect are separate elections; the
+     * capture callback ORs them, so either one excludes an iface. */
+    sloth_state_t s = make_state_with_ifaces(2);
+    iface_only_add(&s, "wlan0");            /* whitelist wlan0 only */
+    s.iface_sel = 1;                        /* wlan0 */
+    view_iface_key(&s, 'y');               /* also deselect wlan0 */
+    ASSERT_EQ(s.iface_only_count,       1);
+    ASSERT_EQ(s.iface_deselected_count, 1);
+    /* wlan0 is whitelisted but deselected → excluded. eth0 is not
+     * whitelisted → excluded. Both drop, by different elections. */
+    ASSERT(iface_is_deselected(&s, "wlan0"));
+    ASSERT_EQ(iface_is_only_allowed(&s, "eth0"), 0);
+}
+
 /* ── view_claims_key: which views own which shadow keys ──────
  *
  * The bug was that the global view-switch handler in main.c consumed
@@ -431,4 +512,13 @@ void run_state_tests(void) {
     RUN_TEST(test_toggle_deselect);
     RUN_TEST(test_toggle_reselect);
     RUN_TEST(test_deselect_independent_of_hide);
+
+    TEST_SUITE("iface data-stream allow-list (--iface/--monitor-only) — #17");
+    RUN_TEST(test_only_empty_allows_all);
+    RUN_TEST(test_only_whitelists_named_iface);
+    RUN_TEST(test_only_add_is_deduped);
+    RUN_TEST(test_only_add_multiple);
+    RUN_TEST(test_only_add_ignores_empty);
+    RUN_TEST(test_only_is_bounded);
+    RUN_TEST(test_only_independent_of_deselect);
 }


### PR DESCRIPTION
Closes #35. Headless follow-up to #17.

## What
Adds a launch-time way to scope sloth's `any` capture to the wireless
monitor radio, for headless/appliance runs where nobody can press the
interactive `y` toggle from #17:

- `--monitor-only` — resolve the monitor-mode Wi-Fi interface at startup
  and restrict the `any` IP/TCP capture to it, dropping loopback / docker
  / wired / VPN noise before decode. The 802.11 SIGINT rides its own
  monitor handle and is unaffected.
- `--iface NAME` (repeatable) — explicit allow-list form.

## How
- New state `iface_only[]` + `iface_is_only_allowed()` / `iface_only_add()`,
  mirroring #17's `iface_deselected[]` / `iface_is_deselected()`.
- `on_packet` (capture.c) ORs the two elections on the existing SLL2
  ingress-attribution path — a frame drops if it's deselected **or** not
  on a non-empty allow-list. Zero new hot-path cost beyond one array scan.
- `main.c`: `--iface` names seeded before `capture_start`; `--monitor-only`
  seeded from `probe_iface` right after `probe_start`. Fail-open with a
  stderr warning when no monitor iface is found — never blinds the sensor.
- iface view: the `d` marker now reflects allow-list exclusion too.

## Tests
7 new state tests (empty=all-pass, whitelist, dedupe, multi, empty/NULL
ignored, bounded at MAX_IFACES, independent-of-deselect). Suite
3606 → 3628 assertions, warning-clean. `main.c` also verified to compile
clean under `WITH_PCAP=0` (the `(void)monitor_only` guard).

## Docs
`docs/views/interfaces.md` gains a "Headless data-stream scoping" section
with the FennecTrace unit example.

## Not in scope
Persistent config-file preferences (still the separate #17 follow-up);
no change to OS interface state or the monitor capture path.
