### PR TITLE
fix(scan): only flag inbound hits on listening ports (closes #41)

### DIFF
--- a/include/sloth.h
+++ b/include/sloth.h
@@ -98,6 +98,13 @@ typedef struct {
 #define PROTO_TCP 6
 #define PROTO_UDP 17
 
+/* TCP socket state (conn_t.state), mirroring the kernel TCP_* enum as
+   reported by /proc/net/tcp. Only LISTEN is consulted outside jsonl's
+   pretty-printer: scan detection uses it to tell an inbound connection
+   (remote reached a port we listen on) from an outbound one whose local
+   port is just an ephemeral source port. See src/scan.c / issue #41. */
+#define TCP_STATE_LISTEN 0x0A
+
 typedef struct {
     char          local_addr[46];
     char          remote_addr[46];

--- a/src/scan.c
+++ b/src/scan.c
@@ -25,15 +25,47 @@ static int scan_is_routable(const char *ip) {
 
 /* ── Core functions ──────────────────────────────────────── */
 
-void scan_update(sloth_state_t *s) {
-    time_t now = time(NULL);
+/* ── Local listening-port set ─────────────────────────────
+   Bitmap over the 65536 TCP ports, one bit per port we LISTEN on.
+   A remote peer that reaches one of these ports connected *to us*;
+   those are the only connections that can be a scan. Ephemeral source
+   ports we open for our own outbound flows (e.g. many parallel sockets
+   to a CDN like Cloudflare/Discord) are never in this set, so outbound
+   traffic can no longer masquerade as an inbound scan. See issue #41.
+   ──────────────────────────────────────────────────────── */
 
-    /* Walk TCP connections: track distinct local_port per remote_addr */
+static void scan_build_listen_set(const sloth_state_t *s, unsigned char bm[8192]) {
+    memset(bm, 0, 8192);
     for (int i = 0; i < s->conn_count; i++) {
         const conn_t *c = &s->conns[i];
         if (c->proto != PROTO_TCP) continue;
+        if (c->state != TCP_STATE_LISTEN) continue;
+        bm[c->local_port >> 3] |= (unsigned char)(1u << (c->local_port & 7));
+    }
+}
+
+static int scan_port_is_local_service(const unsigned char bm[8192], uint16_t port) {
+    return (bm[port >> 3] >> (port & 7)) & 1u;
+}
+
+void scan_update(sloth_state_t *s) {
+    time_t now = time(NULL);
+
+    unsigned char listen_bm[8192];
+    scan_build_listen_set(s, listen_bm);
+
+    /* Walk TCP connections: for each remote peer that reached one of our
+       listening ports, track the distinct local (service) ports it hit. */
+    for (int i = 0; i < s->conn_count; i++) {
+        const conn_t *c = &s->conns[i];
+        if (c->proto != PROTO_TCP) continue;
+        if (c->state == TCP_STATE_LISTEN) continue;   /* the listener itself */
         if (c->remote_addr[0] == '\0') continue;
         if (!scan_is_routable(c->remote_addr)) continue;
+        /* Only count when the local side is the destination — i.e. the
+           remote connected to a port we listen on (remote → us), not a
+           local ephemeral source port from an outbound flow. */
+        if (!scan_port_is_local_service(listen_bm, c->local_port)) continue;
 
         /* find or create entry */
         int found = -1;

--- a/tests/test_scan.c
+++ b/tests/test_scan.c
@@ -10,13 +10,40 @@ static void make_state(sloth_state_t *s) {
     memset(s, 0, sizeof(*s));
 }
 
+/* Model an *inbound* connection: a remote peer reaching one of our
+ * listening service ports (remote → us). Since scan detection now keys
+ * off local ports we LISTEN on (issue #41), each call also seeds a LISTEN
+ * socket on lport. Duplicate LISTEN rows across calls are harmless — the
+ * detector folds them into a per-port bitmap. */
 static void add_tcp_conn(sloth_state_t *s, const char *remote, uint16_t lport) {
+    int l = s->conn_count++;
+    s->conns[l].proto = PROTO_TCP;
+    s->conns[l].state = TCP_STATE_LISTEN;
+    s->conns[l].local_port = lport;
+    snprintf(s->conns[l].local_addr, sizeof(s->conns[l].local_addr), "192.168.1.10");
+
     int i = s->conn_count++;
     s->conns[i].proto = PROTO_TCP;
+    s->conns[i].state = 1;   /* ESTABLISHED */
     snprintf(s->conns[i].remote_addr, sizeof(s->conns[i].remote_addr), "%s", remote);
-    s->conns[i].local_port  = lport;
-    s->conns[i].remote_port = 443;
+    s->conns[i].local_port  = lport;   /* our service port the remote hit */
+    s->conns[i].remote_port = 54321;   /* remote's ephemeral source port */
     snprintf(s->conns[i].local_addr, sizeof(s->conns[i].local_addr), "192.168.1.10");
+}
+
+/* Model an *outbound* connection: our host initiates to a remote service,
+ * so the local port is an ephemeral source port (never a listener) and the
+ * remote port is the service. This is the shape of the Discord/Cloudflare
+ * false positive in issue #41 — it must NOT count as a scan. */
+static void add_outbound_conn(sloth_state_t *s, const char *remote,
+                              uint16_t local_ephemeral, uint16_t remote_service) {
+    int i = s->conn_count++;
+    s->conns[i].proto = PROTO_TCP;
+    s->conns[i].state = 1;   /* ESTABLISHED */
+    snprintf(s->conns[i].remote_addr, sizeof(s->conns[i].remote_addr), "%s", remote);
+    s->conns[i].local_port  = local_ephemeral;
+    s->conns[i].remote_port = remote_service;
+    snprintf(s->conns[i].local_addr, sizeof(s->conns[i].local_addr), "192.168.1.158");
 }
 
 static void test_below_threshold_not_flagged(void) {
@@ -232,6 +259,51 @@ static void test_multiple_ips_independent(void) {
     ASSERT(scan_is_flagged(&s, "203.0.113.20") == 0);
 }
 
+/* issue #41: outbound sockets to a CDN (Cloudflare 162.159.0.0/16, here a
+ * Discord voice/WebSocket session) open many parallel connections to one
+ * remote IP, each with a distinct *ephemeral source* local port. None of
+ * those local ports is a listening service port, so this must never be read
+ * as an inbound port scan. Ports mirror the sample events in the issue. */
+static void test_outbound_cdn_not_flagged(void) {
+    sloth_state_t s; make_state(&s);
+    const uint16_t eph[] = {
+        52484, 60426, 39104, 49164, 40854,
+        33012, 58820, 45001, 61200, 50123,
+    };
+    for (int k = 0; k < (int)(sizeof(eph) / sizeof(eph[0])); k++)
+        add_outbound_conn(&s, "162.159.138.232", eph[k], 443);
+    scan_update(&s);
+    ASSERT(scan_is_flagged(&s, "162.159.138.232") == 0);
+    ASSERT(s.scan_count == 0);
+}
+
+/* A genuine inbound scan and a noisy outbound CDN flow to a *different*
+ * peer, seen at the same time, must not bleed into each other: only the
+ * inbound peer that reached our listening ports is flagged. */
+static void test_inbound_scan_amid_outbound_noise(void) {
+    sloth_state_t s; make_state(&s);
+    /* Outbound noise to Cloudflare — many ephemeral local ports, one peer. */
+    for (uint16_t p = 40000; p < 40016; p++)
+        add_outbound_conn(&s, "104.16.5.5", p, 443);
+    /* Inbound scan: one remote hitting 8 of our listening service ports. */
+    for (uint16_t p = 20; p < 28; p++)
+        add_tcp_conn(&s, "198.51.100.7", p);
+    scan_update(&s);
+    ASSERT(scan_is_flagged(&s, "198.51.100.7") >= SCAN_PORT_THRESH);
+    ASSERT(scan_is_flagged(&s, "104.16.5.5") == 0);
+}
+
+/* An inbound connection to a port we do NOT listen on cannot occur in the
+ * kernel, but guard against a stray/racy conn row without a matching LISTEN
+ * socket being counted: with no listener seeded, nothing is flagged. */
+static void test_no_listener_no_scan(void) {
+    sloth_state_t s; make_state(&s);
+    for (uint16_t p = 1024; p < 1040; p++)
+        add_outbound_conn(&s, "203.0.113.9", p, 80);
+    scan_update(&s);
+    ASSERT(s.scan_count == 0);
+}
+
 static void test_draw_no_scan(void) {
     sloth_state_t s; make_state(&s);
     conn_rebuild_idx(&s);
@@ -271,6 +343,9 @@ void run_scan_tests(void) {
     RUN_TEST(test_routable_boundary_multicast);
     RUN_TEST(test_routable_rejects_malformed_ips);
     RUN_TEST(test_multiple_ips_independent);
+    RUN_TEST(test_outbound_cdn_not_flagged);
+    RUN_TEST(test_inbound_scan_amid_outbound_noise);
+    RUN_TEST(test_no_listener_no_scan);
     RUN_TEST(test_draw_no_scan);
     RUN_TEST(test_draw_with_banner);
 }


### PR DESCRIPTION
## Summary

`scan_update` counted distinct `local_port` per remote IP and flagged a remote once it appeared across ≥ 8 of them. From `/proc/net/tcp` that pattern is exactly what a normal **outbound** flow to a CDN looks like: our host opens many parallel sockets to one Cloudflare IP (a Discord voice/WebSocket session), each with a distinct **ephemeral source** local port. The detector read those source ports as "scanned ports" and fired `scan_entry` against the remote — phantom scanners all over `162.159.0.0/16`. Fixes #41.

The alert semantics (`<ip> scanned N distinct ports`) always meant a **remote** touching many of **our** service ports (remote → us), not us initiating outbound.

## Fix

Direction-aware counting (issue #41's endorsed option 1 — no allowlist needed):

- **`src/scan.c`** — build a bitmap of the local TCP ports we `LISTEN` on, and only count a connection toward a scan entry when its `local_port` is one of them. Ephemeral source ports from outbound flows are never listeners, so an outbound CDN burst can no longer masquerade as a scan. A genuine inbound scan across our listening services is unaffected — the only case `/proc/net/tcp` can witness anyway (closed ports never create a socket).
- **`include/sloth.h`** — add `TCP_STATE_LISTEN` (the state was already parsed from `/proc/net/tcp`; only jsonl's pretty-printer named it before).
- **`tests/test_scan.c`** — rework helpers to model inbound connections (remote → our listening port) and add regressions:
  - the exact Cloudflare/Discord outbound burst from the report stays unflagged
  - an inbound scan amid outbound CDN noise flags **only** the real scanner
  - a conn row with no matching listener is never counted

## Verification

- `make test` → **3801 assertions passed, 0 failed**
- main binary builds clean (`-Wall -Wextra -std=c99`)
- existing PORT_SCAN banner still fires on real inbound scans
- brings the code in line with what `docs/views/alerts.md` already documented ("one source touched ≥ 8 distinct **local** ports") — no doc drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)