### PR TITLE
feat(jsonl): change-only snapshot emission to cut log volume (#42)

### DIFF
--- a/docs/wiki/jsonl-schema.md
+++ b/docs/wiki/jsonl-schema.md
@@ -14,7 +14,7 @@ scripts) code against.
 
 **Sources**: `src/jsonl.c`, `src/data_socket.c`.
 
-**Last updated**: 2026-05-26.
+**Last updated**: 2026-07-18.
 
 ---
 
@@ -293,6 +293,21 @@ These records carry the current contents of each view-backing table.
 (the iOS client; any other view-rebuilding consumer) reconstruct the
 table from the latest snapshot keyed by the natural-identity field
 indicated below. Late-joining clients pick up state on the next tick.
+
+**Change-only emission (issue #42).** The high-volume snapshot types are
+not re-serialised every tick when nothing about a row changed. Each row
+is reduced to a 64-bit signature over its identity + observation fields
+(everything except the envelope `ts`); a row is written only when it is
+new, its signature changed, or `JSONL_HEARTBEAT_SECS` (300 s) have
+elapsed since it was last emitted. This suppresses the idle-repeat
+firehose (≈45 % of production volume was unchanged `seqnum_client` /
+`pnl_client` rows) while the heartbeat guarantees every live entity still
+refreshes at least every 5 minutes, so windowed queries ("who was here
+2–4 AM?") keep working. Consumers see fewer rows but the same
+latest-state-per-key reconstruction; the cache resets on sink (re)open so
+a fresh file always starts with a full baseline. Currently applied to
+`pnl_client` and `seqnum_client`; other snapshot types follow the same
+pattern as they are converted.
 
 | Record               | Identity key      | Fields |
 |----------------------|-------------------|--------|

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -153,3 +153,22 @@ older records simply omit it.
 **Why**: the JSONL schema is a downstream contract (MISSION §3), so a new
 emitted field is logged even though it rode in on a detector change
 rather than a dedicated schema revision.
+
+## 2026-07-18 — Change-only snapshot emission (#42)
+
+**Source**: issue #42 (log volume); commit adding a change cache to
+`src/jsonl.c` that suppresses re-emission of unchanged snapshot rows.
+
+**Doc updates**: [[jsonl-schema]] "State snapshot record types" gained a
+**Change-only emission** paragraph. Rows are now written only when new,
+changed, or `JSONL_HEARTBEAT_SECS` (300 s) stale — no schema/field change,
+purely an emission-cadence change. `pnl_client` and `seqnum_client` are
+converted first (≈45 % of production volume was unchanged rows); other
+snapshot types follow the same pattern later.
+
+**Index updates**: none (no new page).
+
+**Why**: the emission cadence is part of the downstream JSONL contract —
+consumers that assumed one row per entity per tick need to know the stream
+is now change-driven with a 5-minute heartbeat floor, even though the
+per-row fields are unchanged.

--- a/src/jsonl.c
+++ b/src/jsonl.c
@@ -20,6 +20,75 @@ static int any_sink(void) {
     return g_fp != NULL || data_socket_has_clients();
 }
 
+/* ── Change-only snapshot emission (issue #42) ───────────────
+ * The entity-snapshot emitters (pnl_client, seqnum_client, …) run every
+ * poll (~1 Hz) and re-serialise every row whether or not anything
+ * changed. For a mostly idle population that is pure duplication — in
+ * production ~45 % of log volume was unchanged seqnum_client / pnl_client
+ * rows. Each row is reduced to a 64-bit signature of its semantic payload
+ * (identity + observation fields, never the envelope ts) and looked up in
+ * a small direct-mapped cache keyed by the row's natural identity. A row
+ * is written only when it is new, its signature changed, or
+ * JSONL_HEARTBEAT_SECS have elapsed since it was last emitted — so
+ * long-lived idle entities still refresh periodically and windowed
+ * consumers ("who was here 2–4 AM?") keep working.
+ *
+ * The cache is a pure optimisation: a hash collision can only cause an
+ * extra (harmless) emit, never a wrongful suppression, because a slot is
+ * consulted only when its stored identity matches exactly. */
+#define JSONL_HEARTBEAT_SECS 300
+#define JSONL_DEDUP_SLOTS    1024
+#define JSONL_DEDUP_KEYLEN   16
+#define FNV64_OFFSET         0xcbf29ce484222325ULL
+#define FNV64_PRIME          0x100000001b3ULL
+
+typedef struct {
+    uint64_t sig;
+    time_t   emit_ts;
+    uint8_t  key[JSONL_DEDUP_KEYLEN];
+    uint8_t  keylen;
+    uint8_t  kind;
+    uint8_t  used;
+} jsonl_dedup_slot_t;
+
+static jsonl_dedup_slot_t g_dedup[JSONL_DEDUP_SLOTS];
+
+/* Snapshot event "kinds" — one per deduped emitter. */
+enum { JD_PNL = 1, JD_SEQNUM };
+
+static uint64_t fnv1a(const void *data, size_t n, uint64_t h) {
+    const unsigned char *p = (const unsigned char *)data;
+    for (size_t i = 0; i < n; i++) { h ^= p[i]; h *= FNV64_PRIME; }
+    return h;
+}
+
+/* Clear the change cache so the next snapshot re-emits a full baseline.
+ * Called when a sink is (re)opened and available to tests. */
+void jsonl_dedup_reset(void) {
+    memset(g_dedup, 0, sizeof(g_dedup));
+}
+
+/* Returns 1 if a row of this (kind,key) carrying signature `sig` should be
+ * emitted now (new / changed / heartbeat elapsed), 0 to suppress an
+ * unchanged duplicate. Records the decision. */
+static int jsonl_changed(uint8_t kind, const void *key, size_t keylen,
+                         uint64_t sig, time_t now) {
+    if (keylen > JSONL_DEDUP_KEYLEN) keylen = JSONL_DEDUP_KEYLEN;
+    uint64_t h = fnv1a(key, keylen, fnv1a(&kind, 1, FNV64_OFFSET));
+    jsonl_dedup_slot_t *sl = &g_dedup[h % JSONL_DEDUP_SLOTS];
+    int match = sl->used && sl->kind == kind && sl->keylen == (uint8_t)keylen
+                && memcmp(sl->key, key, keylen) == 0;
+    if (match && sl->sig == sig && (now - sl->emit_ts) < JSONL_HEARTBEAT_SECS)
+        return 0;
+    sl->used   = 1;
+    sl->kind   = kind;
+    sl->keylen = (uint8_t)keylen;
+    memcpy(sl->key, key, keylen);
+    sl->sig     = sig;
+    sl->emit_ts = now;
+    return 1;
+}
+
 int jsonl_open(const char *path) {
     if (!path || !path[0]) return 0;
     pthread_mutex_lock(&g_mu);
@@ -27,6 +96,7 @@ int jsonl_open(const char *path) {
     g_fp = fopen(path, "a");
     int ok = g_fp != NULL;
     pthread_mutex_unlock(&g_mu);
+    if (ok) jsonl_dedup_reset();   /* fresh sink → full baseline snapshot */
     return ok;
 }
 
@@ -607,6 +677,21 @@ void jsonl_emit_pnl_clients(const sloth_state_t *s) {
     time_t now = time(NULL);
     for (int i = 0; i < s->pnl_count; i++) {
         const pnl_client_t *e = &s->pnl_clients[i];
+
+        /* Suppress rows unchanged since last emit (issue #42). Signature
+         * covers identity + every observation field serialised below,
+         * excluding only the envelope ts. */
+        uint64_t sig = fnv1a(&e->mac_random,  sizeof(e->mac_random),  FNV64_OFFSET);
+        sig = fnv1a(&e->probe_count, sizeof(e->probe_count), sig);
+        sig = fnv1a(e->os_fp, sizeof(e->os_fp), sig);
+        sig = fnv1a(e->phy,   sizeof(e->phy),   sig);
+        sig = fnv1a(&e->first_seen, sizeof(e->first_seen), sig);
+        sig = fnv1a(&e->last_seen,  sizeof(e->last_seen),  sig);
+        sig = fnv1a(&e->ssid_count, sizeof(e->ssid_count), sig);
+        for (int k = 0; k < e->ssid_count; k++)
+            sig = fnv1a(e->ssids[k], strlen(e->ssids[k]), sig);
+        if (!jsonl_changed(JD_PNL, e->mac, sizeof(e->mac), sig, now)) continue;
+
         char buf[LINEBUF]; int off = 0;
         start_obj(buf, LINEBUF, &off, "pnl_client", now);
         kv_mac(buf, LINEBUF, &off, "mac",         e->mac);
@@ -634,6 +719,17 @@ void jsonl_emit_seqnum_clients(const sloth_state_t *s) {
     time_t now = time(NULL);
     for (int i = 0; i < s->seqnum_count; i++) {
         const seqnum_client_t *e = &s->seqnum_clients[i];
+
+        /* Suppress rows unchanged since last emit (issue #42). frame_count
+         * and hist advance whenever the client is actively seen, so active
+         * devices still emit each cycle; only idle repeats are dropped. */
+        uint64_t sig = fnv1a(&e->mac_random,  sizeof(e->mac_random),  FNV64_OFFSET);
+        sig = fnv1a(&e->last_seen,   sizeof(e->last_seen),   sig);
+        sig = fnv1a(&e->frame_count, sizeof(e->frame_count), sig);
+        sig = fnv1a(&e->hist_n,      sizeof(e->hist_n),      sig);
+        sig = fnv1a(e->hist, (size_t)e->hist_n * sizeof(e->hist[0]), sig);
+        if (!jsonl_changed(JD_SEQNUM, e->mac, sizeof(e->mac), sig, now)) continue;
+
         char buf[LINEBUF]; int off = 0;
         start_obj(buf, LINEBUF, &off, "seqnum_client", now);
         kv_mac(buf, LINEBUF, &off, "mac",         e->mac);

--- a/src/jsonl.h
+++ b/src/jsonl.h
@@ -79,4 +79,8 @@ void jsonl_emit_mqtt_flows    (const sloth_state_t *s);
  * predate this set; this function is purely additive. */
 void jsonl_emit_state_snapshots(sloth_state_t *s);
 
+/* Clear the change-only emission cache (issue #42) so the next snapshot
+ * re-emits a full baseline. Called on sink (re)open; exposed for tests. */
+void jsonl_dedup_reset(void);
+
 #endif /* JSONL_H */

--- a/tests/test_jsonl.c
+++ b/tests/test_jsonl.c
@@ -586,6 +586,99 @@ static void test_emit_packets_once_only(void) {
     ASSERT(line_count(slurp(tmp_path)) == 2);
 }
 
+/* ── change-only snapshot emission (issue #42) ───────────────── */
+
+static void seed_one_pnl(sloth_state_t *s) {
+    memset(s, 0, sizeof(*s));
+    s->pnl_clients[0].mac[0] = 0x02;   /* identity for the dedup key */
+    s->pnl_clients[0].mac[5] = 0x11;
+    snprintf(s->pnl_clients[0].ssids[0], sizeof(s->pnl_clients[0].ssids[0]), "HomeNet");
+    s->pnl_clients[0].ssid_count  = 1;
+    s->pnl_clients[0].probe_count = 3;
+    s->pnl_clients[0].last_seen   = 1700000000;
+    s->pnl_count = 1;
+}
+
+/* An unchanged row emitted twice in a row ships exactly once. */
+static void test_dedup_suppresses_unchanged_pnl(void) {
+    sloth_state_t s; seed_one_pnl(&s);
+    open_fresh();                    /* jsonl_open resets the change cache */
+    jsonl_emit_pnl_clients(&s);
+    jsonl_emit_pnl_clients(&s);      /* nothing changed → suppressed */
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 1);
+}
+
+/* A changed observation field re-emits the row. */
+static void test_dedup_emits_on_change_pnl(void) {
+    sloth_state_t s; seed_one_pnl(&s);
+    open_fresh();
+    jsonl_emit_pnl_clients(&s);
+    s.pnl_clients[0].probe_count = 4;   /* novel observation */
+    jsonl_emit_pnl_clients(&s);
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 2);
+}
+
+/* A new SSID appended to the PNL is a change and re-emits. */
+static void test_dedup_emits_on_new_ssid_pnl(void) {
+    sloth_state_t s; seed_one_pnl(&s);
+    open_fresh();
+    jsonl_emit_pnl_clients(&s);
+    snprintf(s.pnl_clients[0].ssids[1], sizeof(s.pnl_clients[0].ssids[1]), "Cafe");
+    s.pnl_clients[0].ssid_count = 2;
+    jsonl_emit_pnl_clients(&s);
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 2);
+}
+
+/* Two distinct MACs are tracked independently — one changing doesn't
+ * suppress or duplicate the other. */
+static void test_dedup_distinct_macs_independent(void) {
+    sloth_state_t s; seed_one_pnl(&s);
+    s.pnl_clients[1] = s.pnl_clients[0];
+    s.pnl_clients[1].mac[5] = 0x22;     /* different identity */
+    s.pnl_count = 2;
+    open_fresh();
+    jsonl_emit_pnl_clients(&s);          /* both new → 2 lines */
+    jsonl_emit_pnl_clients(&s);          /* both unchanged → 0 lines */
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 2);
+}
+
+/* jsonl_dedup_reset forces a full baseline re-emit (the mechanism a fresh
+ * sink / rotation relies on). */
+static void test_dedup_reset_reemits_baseline(void) {
+    sloth_state_t s; seed_one_pnl(&s);
+    open_fresh();
+    jsonl_emit_pnl_clients(&s);
+    jsonl_dedup_reset();
+    jsonl_emit_pnl_clients(&s);          /* unchanged, but cache cleared */
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 2);
+}
+
+/* seqnum_client dedups on the same principle: identical frame_count/hist
+ * suppresses, an advanced frame_count re-emits. */
+static void test_dedup_seqnum_suppress_then_change(void) {
+    sloth_state_t s; memset(&s, 0, sizeof(s));
+    s.seqnum_clients[0].mac[0]      = 0xde;
+    s.seqnum_clients[0].frame_count = 10;
+    s.seqnum_clients[0].hist[0]     = 0x100;
+    s.seqnum_clients[0].hist_n      = 1;
+    s.seqnum_count = 1;
+
+    open_fresh();
+    jsonl_emit_seqnum_clients(&s);       /* new → 1 */
+    jsonl_emit_seqnum_clients(&s);       /* unchanged → suppressed */
+    s.seqnum_clients[0].frame_count = 11;
+    s.seqnum_clients[0].hist[1]     = 0x105;
+    s.seqnum_clients[0].hist_n      = 2;
+    jsonl_emit_seqnum_clients(&s);       /* advanced → 1 more */
+    jsonl_close();
+    ASSERT(line_count(slurp(tmp_path)) == 2);
+}
+
 /* ── per-record() integration (a parallel write through the log API) ── */
 
 static void test_dns_log_record_writes_jsonl(void) {
@@ -626,6 +719,12 @@ void run_jsonl_tests(void) {
     RUN_TEST(test_emit_state_snapshots_covers_all_view_types);
     RUN_TEST(test_emit_state_snapshots_empty_writes_nothing);
     RUN_TEST(test_emit_packets_once_only);
+    RUN_TEST(test_dedup_suppresses_unchanged_pnl);
+    RUN_TEST(test_dedup_emits_on_change_pnl);
+    RUN_TEST(test_dedup_emits_on_new_ssid_pnl);
+    RUN_TEST(test_dedup_distinct_macs_independent);
+    RUN_TEST(test_dedup_reset_reemits_baseline);
+    RUN_TEST(test_dedup_seqnum_suppress_then_change);
 
     TEST_SUITE("jsonl escaping");
     RUN_TEST(test_json_escapes_quotes_and_backslash);


### PR DESCRIPTION
First, no-dependency step of the #42 storage plan. Attacks the **root cause** of the 12.6 GB/8 h firehose — re-emitting unchanged snapshots — before any archive-side tiering (Parquet/DuckDB/SQLite). Refs #42.

## Problem

The entity-snapshot emitters run every poll (~1 Hz) and re-serialize every row whether or not anything changed. In the production sample on #42, **~45% of volume was unchanged `seqnum_client` + `pnl_client` rows** — snapshots, not novel observations.

## Approach

Same idea as #20's packet emit-once, generalized to entity snapshots. A small **direct-mapped change cache** in `jsonl.c`, keyed by each row's natural identity:

- Each row → a 64-bit FNV-1a signature over its identity + observation fields (never the envelope `ts`).
- A row is written only when it is **new**, its **signature changed**, or **`JSONL_HEARTBEAT_SECS` (300 s)** have elapsed since last emit.
- The heartbeat keeps every live entity refreshing at least every 5 min, so windowed consumers (\"who was here 2–4 AM?\") keep working.
- The cache resets on sink (re)open, so a fresh file always starts with a full baseline.

**Why the cache lives in `jsonl.c`, not the entry structs:** `s->seqnum_clients` / `s->pnl_clients` are per-refresh snapshot *copies* from the trackers' persistent `g_tbl`, so struct-resident dedup state would be clobbered every poll. Keying by identity also makes it **collision-safe** — a hash collision can only cause an extra (harmless) emit, never a wrongful suppression, because a slot is consulted only when its stored identity matches exactly.

## Scope

- Applied to **`pnl_client`** and **`seqnum_client`** (the two biggest types). Other snapshot emitters follow the same pattern in later PRs.
- No schema/field changes — purely emission cadence. Documented in `docs/wiki/jsonl-schema.md` + `log.md`.
- Adds `jsonl_dedup_reset()` (called on open; exposed for tests).

## Tests

Six new tests: suppress-unchanged, emit-on-change, new-SSID, per-MAC independence, reset-rebaselines, and the seqnum path. Full suite: **3813 assertions, 0 failed**; clean build (`-Wall -Wextra -std=c99`), no new warnings.

## Not in scope (deferred per the #42 plan)

Parquet sidecar (Tier 1), DuckDB recipes (Tier 2), SQLite curated state (Tier 3), Neo4j export (Tier 4) — see the maintainer comment on #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)